### PR TITLE
Fixed issue with stake amounts over 10000

### DIFF
--- a/app/shared/actions/system/delegatebw.js
+++ b/app/shared/actions/system/delegatebw.js
@@ -12,8 +12,8 @@ export function delegatebw(delegator, receiver, netAmount, cpuAmount) {
       type: types.SYSTEM_DELEGATEBW_PENDING
     });
 
-    const stakeNetAmount = parseFloat(netAmount || 0).toPrecision(5);
-    const stakeCpuAmount = parseFloat(cpuAmount || 0).toPrecision(5);
+    const stakeNetAmount = netAmount || 0;
+    const stakeCpuAmount = cpuAmount || 0;
 
     return eos(connection).transaction(tr => {
       tr.delegatebw({

--- a/app/shared/actions/system/delegatebw.js
+++ b/app/shared/actions/system/delegatebw.js
@@ -12,8 +12,8 @@ export function delegatebw(delegator, receiver, netAmount, cpuAmount) {
       type: types.SYSTEM_DELEGATEBW_PENDING
     });
 
-    const stakeNetAmount = netAmount || 0;
-    const stakeCpuAmount = cpuAmount || 0;
+    const stakeNetAmount = Math.round(netAmount * 10000) / 10000 || 0;
+    const stakeCpuAmount = Math.round(cpuAmount * 10000) / 10000 || 0;
 
     return eos(connection).transaction(tr => {
       tr.delegatebw({

--- a/app/shared/actions/system/delegatebw.js
+++ b/app/shared/actions/system/delegatebw.js
@@ -28,7 +28,7 @@ export function delegatebw(delegator, receiver, netAmount, cpuAmount) {
       return dispatch({
         payload: { tx },
         type: types.SYSTEM_DELEGATEBW_SUCCESS
-      })
+      });
     }).catch((err) => dispatch({
       payload: { err },
       type: types.SYSTEM_DELEGATEBW_FAILURE

--- a/app/shared/actions/system/undelegatebw.js
+++ b/app/shared/actions/system/undelegatebw.js
@@ -2,7 +2,7 @@ import * as types from '../types';
 import * as AccountActions from '../accounts';
 import eos from '../helpers/eos';
 
-export function undelegatebw(delegator, receiver, net_amount, cpu_amount) {
+export function undelegatebw(delegator, receiver, netAmount, cpuAmount) {
   return (dispatch: () => void, getState) => {
     const {
       connection
@@ -10,17 +10,17 @@ export function undelegatebw(delegator, receiver, net_amount, cpu_amount) {
 
     dispatch({
       type: types.SYSTEM_UNDELEGATEBW_PENDING
-    })
+    });
 
-    const unstake_net_amount = net_amount || 0
-    const unstake_cpu_amount = cpu_amount || 0
+    const unstakeNetAmount = netAmount || 0;
+    const unstakeCpuAmount = cpuAmount || 0;
 
     return eos(connection).transaction(tr => {
       tr.undelegatebw({
         from: delegator,
         receiver,
-        unstake_net_quantity: `${unstake_net_amount} EOS`,
-        unstake_cpu_quantity: `${unstake_cpu_amount} EOS`,
+        unstake_net_quantity: `${unstakeNetAmount} EOS`,
+        unstake_cpu_quantity: `${unstakeCpuAmount} EOS`,
         transfer: 0
       });
     }).then((tx) => {
@@ -28,7 +28,7 @@ export function undelegatebw(delegator, receiver, net_amount, cpu_amount) {
       return dispatch({
         payload: { tx },
         type: types.SYSTEM_UNDELEGATEBW_SUCCESS
-      })
+      });
     }).catch((err) => dispatch({
       payload: { err },
       type: types.SYSTEM_UNDELEGATEBW_FAILURE

--- a/app/shared/actions/system/undelegatebw.js
+++ b/app/shared/actions/system/undelegatebw.js
@@ -12,8 +12,8 @@ export function undelegatebw(delegator, receiver, netAmount, cpuAmount) {
       type: types.SYSTEM_UNDELEGATEBW_PENDING
     });
 
-    const unstakeNetAmount = netAmount || 0;
-    const unstakeCpuAmount = cpuAmount || 0;
+    const unstakeNetAmount = Math.round(netAmount * 10000) / 10000 || 0;
+    const unstakeCpuAmount = Math.round(cpuAmount * 10000) / 10000 || 0;
 
     return eos(connection).transaction(tr => {
       tr.undelegatebw({

--- a/app/shared/actions/system/undelegatebw.js
+++ b/app/shared/actions/system/undelegatebw.js
@@ -12,8 +12,8 @@ export function undelegatebw(delegator, receiver, net_amount, cpu_amount) {
       type: types.SYSTEM_UNDELEGATEBW_PENDING
     })
 
-    const unstake_net_amount = parseFloat(net_amount || 0).toPrecision(5);
-    const unstake_cpu_amount = parseFloat(cpu_amount || 0).toPrecision(5);
+    const unstake_net_amount = net_amount || 0
+    const unstake_cpu_amount = cpu_amount || 0
 
     return eos(connection).transaction(tr => {
       tr.undelegatebw({


### PR DESCRIPTION
I was getting this exception when trying to stake/unstake big amounts and this fix was enough to resolve the issue for me.

```
AssertionError: invalid decimal 4.1823e+5 delegatebw.stake_cpu_quantity action.data transaction.actions
    at UDecimalString (webpack:///./node_modules/eosjs/lib/format.js?:222:5)
    at UDecimalPad (webpack:///./node_modules/eosjs/lib/format.js?:248:15)
    at toAssetString (webpack:///./node_modules/eosjs/lib/structs.js?:425:12)
    at Object.fromObject (webpack:///./node_modules/eosjs/lib/structs.js?:472:16)
    at Object.fromObject (webpack:///./node_modules/fcbuffer/lib/struct.js?:151:34)
  ```

**Also fixed some Eslint errors that I probably caused in a previous PR.