### PR TITLE
Fix .deb download link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Current 0.2.0 release downloads:
 
 - [Windows Installer](https://github.com/greymass/eos-voter/releases/download/v0.2.0/win-eos-voter-0.2.0.exe)
 - [macOS Package](https://github.com/greymass/eos-voter/releases/download/v0.2.0/mac-eos-voter-0.2.0.dmg)
-- [Linux (deb)](https://github.com/greymass/eos-voter/releases/download/v0.2.0/linux-eos-voter-0.2.0-amd64.snap)
+- [Linux (deb)](https://github.com/greymass/eos-voter/releases/download/v0.2.0/linux-eos-voter-0.2.0-amd64.deb)
 - [Linux (snap)](https://github.com/greymass/eos-voter/releases/download/v0.2.0/linux-eos-voter-0.2.0-amd64.snap)
 
 The latest release will always be available on the releases page of this repository:


### PR DESCRIPTION
The link to the .deb installation points to the .snap.