### PR TITLE
Add parsing of contract abi types && Fix symbol precision bug

### DIFF
--- a/app/shared/actions/accounts.js
+++ b/app/shared/actions/accounts.js
@@ -280,7 +280,11 @@ function formatPrecisions(balances) {
   for (let i = 0; i < balances.length; i += 1) {
     const [amount, symbol] = balances[i].split(' ');
     const [, suffix] = amount.split('.');
-    precision[symbol] = suffix.length;
+    var suffixLen = 0;
+    if(suffix !== undefined) {
+        suffixLen = suffix.length;
+    }
+    precision[symbol] = suffixLen;
   }
   return precision;
 }

--- a/app/shared/utils/EOS/Contract.js
+++ b/app/shared/utils/EOS/Contract.js
@@ -3,8 +3,12 @@ import { find, map, pick } from 'lodash';
 const Eos = require('eosjs');
 
 export const typeMap = {
+  int64: 'int',
   uint64: 'int',
+  int32: 'int',
   uint32: 'int',
+  int16: 'int',
+  uint16: 'int',
   bool: 'bool'
 };
 
@@ -13,6 +17,13 @@ export default class EOSContract {
     this.account = account;
     this.abi = abi;
     this.typeMap = typeMap;
+
+    for (var key in abi.types) {
+        var t = abi.types[key];
+        if(t.type in this.typeMap) {
+            this.typeMap[t.new_type_name] = this.typeMap[t.type];
+        }
+    }
   }
 
   tx(actionName, account, data) {


### PR DESCRIPTION
Add missing abi number types and contract abi types parsing. Fix symbol precision format bug where symbol's precision length is 0.