### PR TITLE
Fixed parsing of large integers && Fixed bug when node URL is changed

### DIFF
--- a/app/shared/components/Producers.js
+++ b/app/shared/components/Producers.js
@@ -26,61 +26,6 @@ class Producers extends Component<Props> {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    const { validate } = this.props;
-    const { settings, system } = nextProps;
-    const nextValidate = nextProps.validate;
-    // On a new node connection, update props + producers
-    if (
-      validate.NODE === 'PENDING'
-      && nextValidate.NODE === 'SUCCESS'
-    ) {
-      this.props.actions.getGlobals();
-      this.tick();
-    }
-    // Update state when the transaction has gone through
-    if (
-      this.state.submitting
-      && (
-        this.state.lastTransaction !== system.VOTEPRODUCER_LAST_TRANSACTION
-        || this.state.lastError !== system.VOTEPRODUCER_LAST_ERROR
-      )
-    ) {
-      this.setState({
-        lastError: system.VOTEPRODUCER_LAST_ERROR,
-        lastTransaction: system.VOTEPRODUCER_LAST_TRANSACTION,
-        submitting: false
-      });
-    }
-    // If no selected are loaded, attempt to retrieve them from the props
-    if (
-      !this.state.selected_loaded
-      || this.state.selected_account !== settings.account
-      || (nextProps.producers.proxy && nextProps.producers.proxy !== this.state.selected_account)
-    ) {
-      const { accounts } = nextProps;
-      // If an account is loaded, attempt to load it's votes
-      if (settings.account && accounts[settings.account]) {
-        const account = accounts[settings.account];
-        if (account.voter_info) {
-          const selected_account = account.voter_info.proxy || account.account_name;
-          let selected = account.voter_info.producers
-          if (selected_account !== settings.account && accounts[selected_account]) {
-            selected = accounts[selected_account].voter_info.producers;
-          }
-          // If the voter_info entry exists, load those votes into state
-          this.setState({
-            selected,
-            selected_account,
-            selected_loaded: true
-          });
-        } else {
-          // otherwise notify users that they must stake before allowed voting
-        }
-      }
-    }
-  }
-
   addProxy = (proxyAccout) => {
     this.setState({
       addProxy: proxyAccout

--- a/app/shared/components/Producers/BlockProducers.js
+++ b/app/shared/components/Producers/BlockProducers.js
@@ -28,6 +28,61 @@ class BlockProducers extends Component<Props> {
   resetDisplayAmount = () => this.setState({ amount: 40 });
   isQuerying = (querying) => this.setState({ querying });
 
+  componentWillReceiveProps(nextProps) {
+    const { validate } = this.props;
+    const { settings, system } = nextProps;
+    const nextValidate = nextProps.validate;
+    // On a new node connection, update props + producers
+    if (
+      validate.NODE === 'PENDING'
+      && nextValidate.NODE === 'SUCCESS'
+    ) {
+      this.props.actions.getGlobals();
+      this.tick();
+    }
+    // Update state when the transaction has gone through
+    if (
+      this.state.submitting
+      && (
+        this.state.lastTransaction !== system.VOTEPRODUCER_LAST_TRANSACTION
+        || this.state.lastError !== system.VOTEPRODUCER_LAST_ERROR
+      )
+    ) {
+      this.setState({
+        lastError: system.VOTEPRODUCER_LAST_ERROR,
+        lastTransaction: system.VOTEPRODUCER_LAST_TRANSACTION,
+        submitting: false
+      });
+    }
+    // If no selected are loaded, attempt to retrieve them from the props
+    if (
+      !this.state.selected_loaded
+      || this.state.selected_account !== settings.account
+      || (nextProps.producers.proxy && nextProps.producers.proxy !== this.state.selected_account)
+    ) {
+      const { accounts } = nextProps;
+      // If an account is loaded, attempt to load it's votes
+      if (settings.account && accounts[settings.account]) {
+        const account = accounts[settings.account];
+        if (account.voter_info) {
+          const selected_account = account.voter_info.proxy || account.account_name;
+          let selected = account.voter_info.producers
+          if (selected_account !== settings.account && accounts[selected_account]) {
+            selected = accounts[selected_account].voter_info.producers;
+          }
+          // If the voter_info entry exists, load those votes into state
+          this.setState({
+            selected,
+            selected_account,
+            selected_loaded: true
+          });
+        } else {
+          // otherwise notify users that they must stake before allowed voting
+        }
+      }
+    }
+  }
+
   tick() {
     const {
       actions,

--- a/app/shared/components/Wallet/Panel/Button/Stake.js
+++ b/app/shared/components/Wallet/Panel/Button/Stake.js
@@ -35,6 +35,9 @@ class WalletPanelButtonStake extends Component<Props> {
     } = this.props;
 
     const account = accounts[settings.account];
+    if(!account) {
+      return (null);
+    }
 
     const {
       cpu_weight,

--- a/app/shared/utils/EOS/Contract.js
+++ b/app/shared/utils/EOS/Contract.js
@@ -7,15 +7,9 @@ export const typeMap = {
   int8: 'int',
   int16: 'int',
   int32: 'int',
-  int64: 'int',
-  int128: 'int',
-  int256: 'int',
   uint8: 'int',
   uint16: 'int',
   uint32: 'int',
-  uint64: 'int',
-  uint128: 'int',
-  uint256: 'int',
 };
 
 export default class EOSContract {


### PR DESCRIPTION
This PR removes parsing of integers bigger than 32 bit since java script cannot handle integers larger than 2^53. It can be tested on the Jungle testnet with contract [testcontract](https://jungle.bloks.io/account/testcontract)::printnumbers.

The other part of this PR fixes two bugs that cause app's web canvas to crash due to uncaught exception  when you change the URL address of the node. First bug can be replicated on *Producer Voting* page (invocation of undefined function `tick()`) and second on *Wallet* page when wallet is unlocked.

