### PR TITLE
add chainrifteos and ramtokendapp

### DIFF
--- a/app/shared/constants/exchangeAccounts.js
+++ b/app/shared/constants/exchangeAccounts.js
@@ -1,7 +1,9 @@
 const exchangeAccounts = [
   'binancecleos',
   'bitfinexdep1',
-  'krakenkraken'
+  'chainrifteos',
+  'krakenkraken',
+  'ramtokendapp'
 ];
 
 export default exchangeAccounts;


### PR DESCRIPTION
Added in alphabetical order.
Source for chainrifteos; you need to be signed up, click deposit, it generates that address for you.

Source for ramtokendapp;
https://github.com/ChainRift/RAMtoken#accounts
and 
https://ramtoken.io/ (and click on manual tab)