### PR TITLE
fix: added delband fetch at interval

### DIFF
--- a/app/shared/containers/BasicVoter.js
+++ b/app/shared/containers/BasicVoter.js
@@ -119,7 +119,8 @@ class BasicVoterContainer extends Component<Props> {
       getAccount,
       getConstants,
       getGlobals,
-      getInfo
+      getInfo,
+      getTable
     } = actions;
 
     if (validate.NODE === 'SUCCESS') {
@@ -129,6 +130,7 @@ class BasicVoterContainer extends Component<Props> {
       getConstants();
       getGlobals();
       getInfo();
+      getTable('eosio', settings.account, 'delband');
     }
   }
 


### PR DESCRIPTION
The displayed `Staked To Others` amounts were getting out of sync cause the account was being fetched every 30 seconds but the list of delegations wasn't. Both of these data sets must be valid for the `Staked To Others` amount to be displayed correctly.