### PR TITLE
Node-hid returns null paths

### DIFF
--- a/internals/macos/entitlements.mac.plist
+++ b/internals/macos/entitlements.mac.plist
@@ -6,5 +6,7 @@
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
   </dict>
 </plist>


### PR DESCRIPTION
The new changes for MacOS signing where `"hardenedRuntime": true,` is required creates issues.
This patch fixes the issues with `node-hid`.