### PR TITLE
Removing tools from blockchains and wallets link

### DIFF
--- a/app/modules/main/containers/Content.js
+++ b/app/modules/main/containers/Content.js
@@ -18,6 +18,8 @@ import ToolsContainer from './Sections/Tools';
 import SettingsContainer from './Sections/Settings';
 import VersionContainer from './Sections/Version';
 import WalletContainer from './Sections/Wallet';
+import ToolsWallets from './Sections/Tools/Wallets';
+import GlobalBlockchainManage from '../../../shared/containers/Global/Blockchain/Manage';
 
 class ContentContainer extends Component<Props> {
   render = () => (
@@ -34,6 +36,8 @@ class ContentContainer extends Component<Props> {
           <Route path="/tools" component={ToolsContainer} />
           <Route path="/settings" component={SettingsContainer} />
           <Route path="/version" component={VersionContainer} />
+          <Route path="/manage/wallets" component={ToolsWallets} />
+          <Route path="/manage/blockchains" component={GlobalBlockchainManage} />
         </Switch>
       </HashRouter>
     </Container>

--- a/app/modules/main/containers/Sections/Overview.js
+++ b/app/modules/main/containers/Sections/Overview.js
@@ -144,8 +144,7 @@ class OverviewContainer extends Component<Props> {
                     basic
                     content="Manage Wallets"
                     icon="users"
-                    onClick={() => this.props.actions.changeModule('tools/wallets')}
-
+                    onClick={() => this.props.actions.changeModule('manage/wallets')}
                   />
                 </Container>
               </Segment>

--- a/app/modules/main/containers/Sections/Tools.js
+++ b/app/modules/main/containers/Sections/Tools.js
@@ -54,7 +54,6 @@ class ToolsContainer extends Component<Props> {
           <Route path="/tools/api_ping" component={ToolsApiPing} />
           <Route path="/tools/api_traffic_log" component={ToolsApiTrafficLog} />
           <Route path="/tools/bid_name" component={ToolsBidName} />
-          <Route path="/tools/blockchains" component={GlobalBlockchainManage} />
           <Route path="/tools/chain_state" component={ToolsChainState} />
           <Route path="/tools/contacts" component={ToolsContacts} />
           <Route path="/tools/create_account" component={ToolsCreateAccount} />
@@ -73,7 +72,6 @@ class ToolsContainer extends Component<Props> {
           <Route path="/tools/reset_application" component={ToolsResetApplication} />
           <Route path="/tools/smart_contracts" component={ToolsSmartContracts} />
           <Route path="/tools/wallet_state" component={ToolsWalletState} />
-          <Route path="/tools/wallets" component={ToolsWallets} />
           <Route path="/tools/v1" component={Tools} />
         </Switch>
       </HashRouter>

--- a/app/modules/main/containers/Sections/Tools/Accounts.js
+++ b/app/modules/main/containers/Sections/Tools/Accounts.js
@@ -13,7 +13,7 @@ class ToolsAccountsContainer extends Component<Props> {
     const {
       history,
     } = this.props;
-    history.push('/tools/wallets');
+    history.push('/manage/wallets');
   }
   render() {
     return (

--- a/app/shared/actions/system/voteproducer.js
+++ b/app/shared/actions/system/voteproducer.js
@@ -35,9 +35,9 @@ export function voteproducers(producers = [], proxy = '') {
         }]
       }, {
         blocksBehind: 3,
-        broadcast: false,
+        broadcast: connection.broadcast,
         expireSeconds: 60,
-        sign: false,
+        sign: connection.sign,
       })
       // .voteproducer(account, proxy, producers)
       .then((tx) => {

--- a/app/shared/containers/Global/Account/Dropdown.js
+++ b/app/shared/containers/Global/Account/Dropdown.js
@@ -89,7 +89,7 @@ class GlobalAccountDropdown extends Component<Props> {
                     content="Manage Wallets"
                     fluid
                     icon="users"
-                    onClick={() => this.props.onNavigationChange('tools/wallets')}
+                    onClick={() => this.props.onNavigationChange('manage/wallets')}
                     size="small"
                   />
                 </Dropdown.Header>

--- a/app/shared/containers/Global/Blockchain/Dropdown.js
+++ b/app/shared/containers/Global/Blockchain/Dropdown.js
@@ -116,7 +116,7 @@ class GlobalBlockchainDropdown extends Component<Props> {
                     content="Manage Blockchains"
                     fluid
                     icon="cubes"
-                    onClick={() => this.props.onNavigationChange('tools/blockchains')}
+                    onClick={() => this.props.onNavigationChange('manage/blockchains')}
                     size="small"
                   />
                 </Dropdown.Header>


### PR DESCRIPTION
Made it so the urls for the `Manage Wallets` and `Manage Blockchains` pages are no longer nested under `/tools` and nested under `/manage` instead.